### PR TITLE
매칭 및 댕더패스 구매 시 채팅방 입장 기능 구현

### DIFF
--- a/app/src/main/graphql/com/viewpoint/dangder/chat/mutation.graphql
+++ b/app/src/main/graphql/com/viewpoint/dangder/chat/mutation.graphql
@@ -1,0 +1,15 @@
+mutation JoinChatRoom($dogId : String!, $chatPairId : String!){
+    joinChatRoom(dogId: $dogId, chatPairId: $chatPairId){
+        id
+        chatPairId
+        dog{
+            id
+        }
+        chatMessages {
+            id
+            senderId
+            type
+            message
+        }
+    }
+}

--- a/app/src/main/graphql/com/viewpoint/dangder/chat/mutation.graphql
+++ b/app/src/main/graphql/com/viewpoint/dangder/chat/mutation.graphql
@@ -5,11 +5,6 @@ mutation JoinChatRoom($dogId : String!, $chatPairId : String!){
         dog{
             id
         }
-        chatMessages {
-            id
-            senderId
-            type
-            message
-        }
+
     }
 }

--- a/app/src/main/java/com/viewpoint/dangder/data/mapper/ChatMessageMapper.kt
+++ b/app/src/main/java/com/viewpoint/dangder/data/mapper/ChatMessageMapper.kt
@@ -1,0 +1,32 @@
+package com.viewpoint.dangder.data.mapper
+
+import com.viewpoint.JoinChatRoomMutation
+import com.viewpoint.dangder.domain.entity.*
+
+object ChatMessageMapper {
+    fun mapToChatMessage(messageData: JoinChatRoomMutation.ChatMessage): ChatMessage {
+        return when (messageData.type) {
+            ChatMessageType.TEXT.name -> TextMessage(
+                id = messageData.id,
+                senderId = messageData.senderId,
+                type = ChatMessageType.TEXT,
+                message =  messageData.message
+            )
+            ChatMessageType.PLAN.name -> PlanMessage(
+                id = messageData.id,
+                senderId = messageData.senderId,
+                type = ChatMessageType.PLAN
+            )
+            ChatMessageType.PLACE.name -> PlaceMessage(
+                id = messageData.id,
+                senderId = messageData.senderId,
+                type = ChatMessageType.PLACE
+            )
+            else-> object : ChatMessage(){
+                override var id: String = ""
+                override var type: ChatMessageType = ChatMessageType.NONE
+                override var senderId: String=""
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/viewpoint/dangder/data/mapper/ChatMessageMapper.kt
+++ b/app/src/main/java/com/viewpoint/dangder/data/mapper/ChatMessageMapper.kt
@@ -4,29 +4,29 @@ import com.viewpoint.JoinChatRoomMutation
 import com.viewpoint.dangder.domain.entity.*
 
 object ChatMessageMapper {
-    fun mapToChatMessage(messageData: JoinChatRoomMutation.ChatMessage): ChatMessage {
-        return when (messageData.type) {
-            ChatMessageType.TEXT.name -> TextMessage(
-                id = messageData.id,
-                senderId = messageData.senderId,
-                type = ChatMessageType.TEXT,
-                message =  messageData.message
-            )
-            ChatMessageType.PLAN.name -> PlanMessage(
-                id = messageData.id,
-                senderId = messageData.senderId,
-                type = ChatMessageType.PLAN
-            )
-            ChatMessageType.PLACE.name -> PlaceMessage(
-                id = messageData.id,
-                senderId = messageData.senderId,
-                type = ChatMessageType.PLACE
-            )
-            else-> object : ChatMessage(){
-                override var id: String = ""
-                override var type: ChatMessageType = ChatMessageType.NONE
-                override var senderId: String=""
-            }
-        }
-    }
+//    fun mapToChatMessage(messageData: JoinChatRoomMutation): ChatMessage {
+//        return when (messageData.type) {
+//            ChatMessageType.TEXT.name -> TextMessage(
+//                id = messageData.id,
+//                senderId = messageData.senderId,
+//                type = ChatMessageType.TEXT,
+//                message =  messageData.message
+//            )
+//            ChatMessageType.PLAN.name -> PlanMessage(
+//                id = messageData.id,
+//                senderId = messageData.senderId,
+//                type = ChatMessageType.PLAN
+//            )
+//            ChatMessageType.PLACE.name -> PlaceMessage(
+//                id = messageData.id,
+//                senderId = messageData.senderId,
+//                type = ChatMessageType.PLACE
+//            )
+//            else-> object : ChatMessage(){
+//                override var id: String = ""
+//                override var type: ChatMessageType = ChatMessageType.NONE
+//                override var senderId: String=""
+//            }
+//        }
+//    }
 }

--- a/app/src/main/java/com/viewpoint/dangder/data/mapper/ChatRoomMapper.kt
+++ b/app/src/main/java/com/viewpoint/dangder/data/mapper/ChatRoomMapper.kt
@@ -1,0 +1,14 @@
+package com.viewpoint.dangder.data.mapper
+
+import com.viewpoint.JoinChatRoomMutation
+import com.viewpoint.dangder.domain.entity.ChatRoom
+
+object ChatRoomMapper {
+    fun mapToChatRoomEntity(chatRoomData: JoinChatRoomMutation.JoinChatRoom) = ChatRoom(
+        id = chatRoomData.id,
+        pairDogId = chatRoomData.chatPairId,
+        chatMessages = chatRoomData.chatMessages.map {
+            ChatMessageMapper.mapToChatMessage(it)
+        }
+    )
+}

--- a/app/src/main/java/com/viewpoint/dangder/data/mapper/ChatRoomMapper.kt
+++ b/app/src/main/java/com/viewpoint/dangder/data/mapper/ChatRoomMapper.kt
@@ -7,8 +7,5 @@ object ChatRoomMapper {
     fun mapToChatRoomEntity(chatRoomData: JoinChatRoomMutation.JoinChatRoom) = ChatRoom(
         id = chatRoomData.id,
         pairDogId = chatRoomData.chatPairId,
-        chatMessages = chatRoomData.chatMessages.map {
-            ChatMessageMapper.mapToChatMessage(it)
-        }
     )
 }

--- a/app/src/main/java/com/viewpoint/dangder/data/remote/ChatRemoteDataSource.kt
+++ b/app/src/main/java/com/viewpoint/dangder/data/remote/ChatRemoteDataSource.kt
@@ -1,0 +1,25 @@
+package com.viewpoint.dangder.data.remote
+
+import com.apollographql.apollo3.ApolloClient
+import com.apollographql.apollo3.api.ApolloResponse
+import com.viewpoint.JoinChatRoomMutation
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class ChatRemoteDataSource @Inject constructor(
+    private val apolloClient: ApolloClient
+) {
+
+    suspend fun joinChatRoom(
+        myDogId: String,
+        pairDogId: String
+    ): ApolloResponse<JoinChatRoomMutation.Data> {
+        return withContext(Dispatchers.IO) {
+            apolloClient.mutation(JoinChatRoomMutation(dogId = myDogId, chatPairId = pairDogId))
+                .execute()
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/viewpoint/dangder/data/repository/ChatRepositoryImpl.kt
+++ b/app/src/main/java/com/viewpoint/dangder/data/repository/ChatRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.viewpoint.dangder.data.repository
+
+import com.viewpoint.dangder.data.mapper.ChatRoomMapper
+import com.viewpoint.dangder.data.remote.ChatRemoteDataSource
+import com.viewpoint.dangder.domain.entity.ChatRoom
+import com.viewpoint.dangder.domain.repository.ChatRepository
+import javax.inject.Inject
+
+class ChatRepositoryImpl @Inject constructor(
+    private val chatRemoteDataSource: ChatRemoteDataSource
+):ChatRepository  {
+    override suspend fun joinChatRoom(myDogId: String, pairDogId: String): ChatRoom {
+        val response = chatRemoteDataSource.joinChatRoom(myDogId= myDogId, pairDogId = pairDogId)
+
+        if(response.hasErrors()) throw Exception(response.errors?.first()?.message)
+
+        val chatRoomData = response.data?.joinChatRoom ?: throw Exception("데이터가 존재하지 않습니다.")
+
+        return ChatRoomMapper.mapToChatRoomEntity(chatRoomData)
+    }
+}

--- a/app/src/main/java/com/viewpoint/dangder/di/RepositoryModule.kt
+++ b/app/src/main/java/com/viewpoint/dangder/di/RepositoryModule.kt
@@ -28,4 +28,6 @@ abstract class RepositoryModule {
     @Binds
     abstract fun bindPaymentRepository(paymentRepository: PaymentRepositoryImpl) : PaymentRepository
 
+    @Binds
+    abstract fun bindChatRepository(chatRepository: ChatRepositoryImpl) : ChatRepository
 }

--- a/app/src/main/java/com/viewpoint/dangder/di/UseCaseModule.kt
+++ b/app/src/main/java/com/viewpoint/dangder/di/UseCaseModule.kt
@@ -1,8 +1,10 @@
 package com.viewpoint.dangder.di
 
 import com.viewpoint.dangder.domain.repository.AuthRepository
+import com.viewpoint.dangder.domain.repository.ChatRepository
 import com.viewpoint.dangder.domain.repository.DogRepository
 import com.viewpoint.dangder.domain.repository.SettingsRepository
+import com.viewpoint.dangder.domain.usecase.EnterChatRoomUseCase
 import com.viewpoint.dangder.domain.usecase.auth.*
 import com.viewpoint.dangder.domain.usecase.dog.*
 import dagger.Module
@@ -61,4 +63,9 @@ object UseCaseModule {
         settingsRepository: SettingsRepository
     ) = FetchAroundDogsUseCase(dogRepository, settingsRepository)
 
+    @Provides
+    fun providesEnterChatRoomUseCase(
+        chatRepository: ChatRepository,
+        settingsRepository: SettingsRepository
+    ) = EnterChatRoomUseCase(chatRepository, settingsRepository)
 }

--- a/app/src/main/java/com/viewpoint/dangder/domain/entity/ChatMessage.kt
+++ b/app/src/main/java/com/viewpoint/dangder/domain/entity/ChatMessage.kt
@@ -1,0 +1,36 @@
+package com.viewpoint.dangder.domain.entity
+
+enum class ChatMessageType(name: String) {
+    TEXT(name = "text"),
+    PLACE(name = "place"),
+    PLAN(name = "plan"),
+    NONE(name = "none")
+}
+
+abstract class ChatMessage {
+    abstract var id: String
+    abstract var type: ChatMessageType
+    abstract var senderId: String
+}
+
+data class TextMessage(
+    override var id: String,
+    override var senderId: String,
+    override var type: ChatMessageType = ChatMessageType.TEXT,
+    val message : String? = null
+) : ChatMessage()
+
+data class PlaceMessage(
+    override var id: String,
+    override var type: ChatMessageType = ChatMessageType.PLACE,
+    override var senderId: String,
+    val lat : Double? = null,
+    val lng : Double? = null
+) : ChatMessage()
+
+data class PlanMessage(
+    override var id: String,
+    override var type: ChatMessageType = ChatMessageType.PLAN,
+    override var senderId: String,
+    val meetAt : String? = null
+) : ChatMessage()

--- a/app/src/main/java/com/viewpoint/dangder/domain/entity/ChatRoom.kt
+++ b/app/src/main/java/com/viewpoint/dangder/domain/entity/ChatRoom.kt
@@ -1,0 +1,7 @@
+package com.viewpoint.dangder.domain.entity
+
+data class ChatRoom(
+    val id : String,
+    val pairDogId : String,
+    val chatMessages : List<ChatMessage>? = emptyList()
+)

--- a/app/src/main/java/com/viewpoint/dangder/domain/repository/ChatRepository.kt
+++ b/app/src/main/java/com/viewpoint/dangder/domain/repository/ChatRepository.kt
@@ -1,0 +1,7 @@
+package com.viewpoint.dangder.domain.repository
+
+import com.viewpoint.dangder.domain.entity.ChatRoom
+
+interface ChatRepository {
+    suspend fun joinChatRoom(myDogId : String, pairDogId : String) : ChatRoom
+}

--- a/app/src/main/java/com/viewpoint/dangder/domain/usecase/EnterChatRoomUseCase.kt
+++ b/app/src/main/java/com/viewpoint/dangder/domain/usecase/EnterChatRoomUseCase.kt
@@ -1,0 +1,22 @@
+package com.viewpoint.dangder.domain.usecase
+
+import com.viewpoint.dangder.domain.entity.ChatRoom
+import com.viewpoint.dangder.domain.repository.ChatRepository
+import com.viewpoint.dangder.domain.repository.SettingsRepository
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class EnterChatRoomUseCase @Inject constructor(
+    private val chatRepository: ChatRepository,
+    private val settingsRepository: SettingsRepository
+) {
+
+    suspend operator fun invoke(pairDogId : String): ChatRoom {
+        try {
+            val myDogId = settingsRepository.getDogId().first()
+            return chatRepository.joinChatRoom(myDogId = myDogId, pairDogId = pairDogId)
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+}

--- a/app/src/main/java/com/viewpoint/dangder/presenter/action/Actions.kt
+++ b/app/src/main/java/com/viewpoint/dangder/presenter/action/Actions.kt
@@ -10,6 +10,7 @@ sealed class Actions {
     object GoToLoginPage : Actions()
     object GoToNextPage : Actions()
     data class GoToInitDogPage(val userId: String? = null) : Actions()
+    data class GoToChatRoomPage(val roomId : String) : Actions()
 
     // common action
     object ShowLoadingDialog : Actions()
@@ -29,6 +30,6 @@ sealed class Actions {
     data class FetchOneDog(val data : Dog) : Actions()
 
     //
-    object ShowBuyPassTicketDialog : Actions()
+    data class ShowBuyPassTicketDialog(val pairDogId: String? = null) : Actions()
 
 }

--- a/app/src/main/java/com/viewpoint/dangder/presenter/dialog/BuyPassTicketDialog.kt
+++ b/app/src/main/java/com/viewpoint/dangder/presenter/dialog/BuyPassTicketDialog.kt
@@ -10,7 +10,8 @@ import com.viewpoint.dangder.databinding.DialogBuyPassticketBinding
 import com.viewpoint.dangder.presenter.main.MainViewModel
 
 class BuyPassTicketDialog(
-    private val mainViewModel: MainViewModel
+    private val mainViewModel: MainViewModel,
+    private val pairDogId : String? = null
 ) : BottomSheetDialogFragment() {
 
     private lateinit var binding: DialogBuyPassticketBinding
@@ -32,7 +33,7 @@ class BuyPassTicketDialog(
 
     private fun handleClickBuyPassTicket() {
         binding.paymentDialogBuyButton.setOnClickListener {
-            mainViewModel.requestBuyPassTicket(Iamport)
+            mainViewModel.requestBuyPassTicket(Iamport, pairDogId)
         }
     }
 

--- a/app/src/main/java/com/viewpoint/dangder/presenter/dialog/MatchedDialog.kt
+++ b/app/src/main/java/com/viewpoint/dangder/presenter/dialog/MatchedDialog.kt
@@ -10,9 +10,11 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import com.viewpoint.dangder.databinding.DialogMatchedBinding
 import com.viewpoint.dangder.domain.entity.Dog
+import com.viewpoint.dangder.presenter.main.MainViewModel
 
 
 class MatchedDialog(
+    private val mainViewModel : MainViewModel,
     private val pairDog: Dog,
 ) : DialogFragment() {
 
@@ -41,11 +43,13 @@ class MatchedDialog(
     private fun initView() {
         binding.dog = pairDog
         handleClickClose()
+        handleClickGoChat()
     }
 
     private fun handleClickGoChat() {
         binding.matchChatBtn.setOnClickListener {
-            // todo : ChatViewModel에 joinChatRoom 요청
+            mainViewModel.enterChatRoom(pairDogId = pairDog.id)
+            this.dismiss()
         }
     }
 

--- a/app/src/main/res/layout/fragment_chat_room.xml
+++ b/app/src/main/res/layout/fragment_chat_room.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<layout>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto">
     <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="여기는 채팅방 페이지"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/main_nav_graph.xml
+++ b/app/src/main/res/navigation/main_nav_graph.xml
@@ -11,6 +11,9 @@
         <action
             android:id="@+id/action_mainFragment_to_detailFragment"
             app:destination="@id/detailFragment" />
+        <action
+            android:id="@+id/action_mainFragment_to_chatRoomFragment"
+            app:destination="@id/chatRoomFragment" />
 
     </fragment>
     <fragment
@@ -32,7 +35,11 @@
     <fragment
         android:id="@+id/chatRoomFragment"
         android:name="com.viewpoint.dangder.presenter.chat.ChatRoomFragment"
-        android:label="ChatRoomFragment" />
+        android:label="ChatRoomFragment" >
+        <argument
+            android:name="chatRoomId"
+            app:argType="string" />
+    </fragment>
     <fragment
         android:id="@+id/detailFragment"
         android:name="com.viewpoint.dangder.presenter.main.DetailFragment"
@@ -41,5 +48,8 @@
             android:name="dogId"
             app:argType="string"
             android:defaultValue='""' />
+        <action
+            android:id="@+id/action_detailFragment_to_chatRoomFragment"
+            app:destination="@id/chatRoomFragment" />
     </fragment>
 </navigation>


### PR DESCRIPTION
## Issue 번호
close #51 

## 작업 내역
- joinChatRoom API 연동
- ChatRepository 생성 
- EnterChatRoomUseCase 생성

## 변경 사항
- MainViewModel에 enterChatRoom 메소드 추가

## 새로운 기능
- 사용자는 매칭 및 댕더패스 구매로 상대방과 채팅할 수 있다.

## 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 업데이트

## 체크리스트
- [x] Merge 대상 branch가 올바른가?
- [x] 약속된 컨벤션 (on code, commit, issue...) 을 준수하는가?
- [x] PR과 관련없는 변경사항이 없는가?
